### PR TITLE
Bugfix: Uses `module.this.enabled` instead of vars.enabled

### DIFF
--- a/src/policy-team-role-access.tf
+++ b/src/policy-team-role-access.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "team_role_access" {
 }
 
 resource "aws_iam_policy" "team_role_access" {
-  count       = var.enabled ? 1 : 0
+  count       = module.this.enabled ? 1 : 0
   name        = format("%s-TeamRoleAccess", module.this.id)
   description = "IAM permission to use AssumeRole"
   policy      = data.aws_iam_policy_document.team_role_access.json


### PR DESCRIPTION
## what
* context.tf by default sets the `var.enabled` to `null`. we then merge this in with module context whos' default is true. 

## why
* Bugfix 
## references
* fixes: #23 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->