### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "aws_saml" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component  = "aws-saml"
+  component  = var.aws_saml_component_name
   privileged = true
 
   ignore_errors = true
@@ -18,7 +18,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   tenant      = module.iam_roles.global_tenant_name
   environment = module.iam_roles.global_environment_name
   stage       = module.iam_roles.global_stage_name

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -53,3 +53,15 @@ variable "account_map_stage_name" {
   description = "The name of the stage where `account_map` is provisioned"
   default     = "root"
 }
+
+variable "aws_saml_component_name" {
+  type        = string
+  description = "The name of the aws-saml component"
+  default     = "aws-saml"
+}
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variables `aws_saml_component_name` and `account_map_component_name`.
* Variables default to preserving the behaviour of the current version.
* Remote state uses these variables to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.