### PR TITLE
Migrate README generation to atmos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ aws-assumed-role/
 *.iml
 .direnv
 .envrc
+.cache
+.atmos
 
 # Compiled and auto-generated files
 # Note that the leading "**/" appears necessary for Docker even if not for Git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/`: Terraform component (`main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `versions.tf`, `context.tf`). This is the source of truth.
+- `test/`: Go Terratest suite using Atmos fixtures (`component_test.go`, `fixtures/`, `test_suite.yaml`). Tests deploy/destroy real AWS resources.
+- `README.yaml`: Source for the generated `README.md` (via atmos + terraform-docs).
+- `.github/`: CI/CD, Renovate/Dependabot, labels, and automerge settings.
+- `docs/`: Project docs (if any). Keep lightweight and current.
+
+## Build, Test, and Development Commands
+- To install atmos read this docs https://github.com/cloudposse/atmos
+- `atmos docs generate readme`: Regenerate `README.md` from `README.yaml` and terraform source.
+- `atmos docs generate readme-simple`: Regenerate `src/README.md` from `README.yaml` and terraform source.
+- `atmos test run`: Run Terratest suite in `test/` (uses Atmos fixtures; creates and destroys AWS resources).
+- Pre-commit locally: `pre-commit install && pre-commit run -a` (runs `terraform_fmt`, `terraform_docs`, `tflint`).
+- TFLint plugin setup: `tflint --init` (uses `.tflint.hcl`).
+
+## Coding Style & Naming Conventions
+- Indentation: Terraform 2 spaces; YAML/Markdown 2 spaces.
+- Terraform: prefer lower_snake_case for variables/locals; keep resources/data sources descriptive and aligned with Cloud Posse null-label patterns.
+- Lint/format: `terraform fmt -recursive`, TFLint rules per `.tflint.hcl`. Do not commit formatting or lint violations.
+
+## Testing Guidelines
+- Framework: Go Terratest with `github.com/cloudposse/test-helpers` and `atmos` fixtures.
+- Location/naming: put tests in `test/` and name files `*_test.go`. Add scenarios under `test/fixtures/stacks/catalog/usecase/`.
+- Run: `atmos test run`. Ensure AWS credentials are configured; tests may incur AWS costs and will clean up after themselves.
+
+## Commit & Pull Request Guidelines
+- Commits: follow Conventional Commits (e.g., `feat:`, `fix:`, `chore(deps):`, `docs:`). Keep messages concise and scoped.
+- PRs: include a clear description, linked issues, and any behavioral changes. Update `README.yaml` when inputs/outputs change and run `atmos docs generate readme`.
+- CI: ensure pre-commit, TFLint, and tests pass. Avoid unrelated changes in the same PR.
+
+## Security & Configuration Tips
+- Never commit secrets. Configure AWS credentials/role assumption externally; the provider setup in `src/providers.tf` supports role assumption via the `iam_roles` module.
+- Global quotas must be applied in `us-east-1`; place in the `gbl` stack and set `region: us-east-1` in `vars`.

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
--include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
-
-all: init readme
-
-test::
-	@echo "🚀 Starting tests..."
-	./test/run.sh
-	@echo "✅ All tests passed."

--- a/README.yaml
+++ b/README.yaml
@@ -46,8 +46,39 @@ description: |-
   The `aws-sso` component can create AWS Permission Sets that allow users to assume specific roles in the `identity`
   account. See the `aws-sso` component for details.
 
-  ## Usage
+  ## Known Problems
 
+  ### Error: `assume role policy: LimitExceeded: Cannot exceed quota for ACLSizePerRole: 2048`
+
+  The `aws-teams` architecture, when enabling access to a role via lots of AWS SSO Profiles, can create large "assume
+  role" policies, large enough to exceed the default quota of 2048 characters. If you run into this limitation, you will
+  get an error like this:
+
+  ```
+  Error: error updating IAM Role (acme-gbl-root-tfstate-backend-analytics-ro) assume role policy: LimitExceeded: Cannot exceed quota for ACLSizePerRole: 2048
+  ```
+
+  This can happen in either/both the `identity` and `root` accounts (for Terraform state access). So far, we have always
+  been able to resolve this by requesting a quota increase, which is automatically granted a few minutes after making the
+  request. To request the quota increase:
+
+  - Log in to the AWS Web console as admin in the affected account
+
+  - Set your region to N. Virginia `us-east-1`
+
+  - Navigate to the Service Quotas page via the account dropdown menu
+
+  - Click on AWS Services in the left sidebar
+
+  - Search for "IAM" and select "AWS Identity and Access Management (IAM)". (If you don't find that option, make sure you
+    have selected the `us-east-1` region.
+
+  - Find and select "Role trust policy length"
+
+  - Request an increase to 4096 characters
+
+  - Wait for the request to be approved, usually less than a few minutes
+usage: |-
   **Stack Level**: Global **Deployment**: Must be deployed by SuperAdmin using `atmos` CLI
 
   Here's an example snippet for how to use this component. The component should only be applied once, which is typically
@@ -133,122 +164,11 @@ description: |-
   ```
 
   <!-- prettier-ignore-start -->
-  <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-  ## Requirements
-
-  | Name | Version |
-  |------|---------|
-  | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-  | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
-  | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-
-  ## Providers
-
-  | Name | Version |
-  |------|---------|
-  | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
-  | <a name="provider_local"></a> [local](#provider\_local) | >= 1.3 |
-
-  ## Modules
-
-  | Name | Source | Version |
-  |------|--------|---------|
-  | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-  | <a name="module_assume_role"></a> [assume\_role](#module\_assume\_role) | ../account-map/modules/team-assume-role-policy | n/a |
-  | <a name="module_aws_saml"></a> [aws\_saml](#module\_aws\_saml) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-  | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-  | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-
-  ## Resources
-
-  | Name | Type |
-  |------|------|
-  | [aws_iam_policy.team_role_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-  | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-  | [aws_iam_role_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-  | [local_file.account_info](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-  | [aws_iam_policy_document.assume_role_aggregated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-  | [aws_iam_policy_document.team_role_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-
-  ## Inputs
-
-  | Name | Description | Type | Default | Required |
-  |------|-------------|------|---------|:--------:|
-  | <a name="input_account_map_environment_name"></a> [account\_map\_environment\_name](#input\_account\_map\_environment\_name) | The name of the environment where `account_map` is provisioned | `string` | `"gbl"` | no |
-  | <a name="input_account_map_stage_name"></a> [account\_map\_stage\_name](#input\_account\_map\_stage\_name) | The name of the stage where `account_map` is provisioned | `string` | `"root"` | no |
-  | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-  | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-  | <a name="input_aws_saml_environment_name"></a> [aws\_saml\_environment\_name](#input\_aws\_saml\_environment\_name) | The name of the environment where SSO is provisioned | `string` | `"gbl"` | no |
-  | <a name="input_aws_saml_stage_name"></a> [aws\_saml\_stage\_name](#input\_aws\_saml\_stage\_name) | The name of the stage where SSO is provisioned | `string` | `"identity"` | no |
-  | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
-  | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-  | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-  | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-  | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-  | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-  | <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
-  | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
-  | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
-  | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
-  | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-  | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
-  | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-  | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-  | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-  | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-  | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-  | <a name="input_teams_config"></a> [teams\_config](#input\_teams\_config) | A roles map to configure the accounts. | <pre>map(object({<br>    denied_teams            = list(string)<br>    denied_permission_sets  = list(string)<br>    denied_role_arns        = list(string)<br>    max_session_duration    = number # in seconds 3600 <= max <= 43200 (12 hours)<br>    role_description        = string<br>    role_policy_arns        = list(string)<br>    aws_saml_login_enabled  = bool<br>    allowed_roles           = optional(map(list(string)), {})<br>    trusted_teams           = list(string)<br>    trusted_permission_sets = list(string)<br>    trusted_role_arns       = list(string)<br>  }))</pre> | n/a | yes |
-  | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-  | <a name="input_trusted_github_repos"></a> [trusted\_github\_repos](#input\_trusted\_github\_repos) | Map where keys are role names (same keys as `teams_config`) and values are lists of<br>GitHub repositories allowed to assume those roles. See `account-map/modules/github-assume-role-policy.mixin.tf`<br>for specifics about repository designations. | `map(list(string))` | `{}` | no |
-
-  ## Outputs
-
-  | Name | Description |
-  |------|-------------|
-  | <a name="output_role_arns"></a> [role\_arns](#output\_role\_arns) | List of role ARNs |
-  | <a name="output_team_name_role_arn_map"></a> [team\_name\_role\_arn\_map](#output\_team\_name\_role\_arn\_map) | Map of team names to role ARNs |
-  | <a name="output_team_names"></a> [team\_names](#output\_team\_names) | List of team names |
-  | <a name="output_teams_config"></a> [teams\_config](#output\_teams\_config) | Map of team config with name, target arn, and description |
-  <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
   <!-- prettier-ignore-end -->
-
-  ## Known Problems
-
-  ### Error: `assume role policy: LimitExceeded: Cannot exceed quota for ACLSizePerRole: 2048`
-
-  The `aws-teams` architecture, when enabling access to a role via lots of AWS SSO Profiles, can create large "assume
-  role" policies, large enough to exceed the default quota of 2048 characters. If you run into this limitation, you will
-  get an error like this:
-
-  ```
-  Error: error updating IAM Role (acme-gbl-root-tfstate-backend-analytics-ro) assume role policy: LimitExceeded: Cannot exceed quota for ACLSizePerRole: 2048
-  ```
-
-  This can happen in either/both the `identity` and `root` accounts (for Terraform state access). So far, we have always
-  been able to resolve this by requesting a quota increase, which is automatically granted a few minutes after making the
-  request. To request the quota increase:
-
-  - Log in to the AWS Web console as admin in the affected account
-
-  - Set your region to N. Virginia `us-east-1`
-
-  - Navigate to the Service Quotas page via the account dropdown menu
-
-  - Click on AWS Services in the left sidebar
-
-  - Search for "IAM" and select "AWS Identity and Access Management (IAM)". (If you don't find that option, make sure you
-    have selected the `us-east-1` region.
-
-  - Find and select "Role trust policy length"
-
-  - Request an increase to 4096 characters
-
-  - Wait for the request to be approved, usually less than a few minutes
-
-  ## References
-
-  - [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components)- Cloud Posse's upstream
-    component
+references:
+  - name: "cloudposse-terraform-components"
+    description: "Cloud Posse's upstream component"
+    url: "https://github.com/orgs/cloudposse-terraform-components/repositories"
 tags:
   - component/aws-teams
   - layer/identity

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -1,0 +1,11 @@
+# Atmos Configuration — powered by https://atmos.tools
+#
+# This configuration enables centralized, DRY, and consistent project scaffolding using Atmos.
+#
+# Included features:
+# - Organizational custom commands: https://atmos.tools/core-concepts/custom-commands
+# - Automated README generation: https://atmos.tools/cli/commands/docs/generate
+#
+# Import shared configuration used by all modules
+import:
+  - https://raw.githubusercontent.com/cloudposse-terraform-components/.github/refs/heads/main/.github/atmos/terraform-component.yaml

--- a/src/README.md
+++ b/src/README.md
@@ -51,6 +51,38 @@ Users can again access to a role in the `identity` account through either (or bo
 The `aws-sso` component can create AWS Permission Sets that allow users to assume specific roles in the `identity`
 account. See the `aws-sso` component for details.
 
+## Known Problems
+
+### Error: `assume role policy: LimitExceeded: Cannot exceed quota for ACLSizePerRole: 2048`
+
+The `aws-teams` architecture, when enabling access to a role via lots of AWS SSO Profiles, can create large "assume
+role" policies, large enough to exceed the default quota of 2048 characters. If you run into this limitation, you will
+get an error like this:
+
+```
+Error: error updating IAM Role (acme-gbl-root-tfstate-backend-analytics-ro) assume role policy: LimitExceeded: Cannot exceed quota for ACLSizePerRole: 2048
+```
+
+This can happen in either/both the `identity` and `root` accounts (for Terraform state access). So far, we have always
+been able to resolve this by requesting a quota increase, which is automatically granted a few minutes after making the
+request. To request the quota increase:
+
+- Log in to the AWS Web console as admin in the affected account
+
+- Set your region to N. Virginia `us-east-1`
+
+- Navigate to the Service Quotas page via the account dropdown menu
+
+- Click on AWS Services in the left sidebar
+
+- Search for "IAM" and select "AWS Identity and Access Management (IAM)". (If you don't find that option, make sure you
+  have selected the `us-east-1` region.
+
+- Find and select "Role trust policy length"
+
+- Request an increase to 4096 characters
+
+- Wait for the request to be approved, usually less than a few minutes
 ## Usage
 
 **Stack Level**: Global **Deployment**: Must be deployed by SuperAdmin using `atmos` CLI
@@ -138,7 +170,10 @@ components:
 ```
 
 <!-- prettier-ignore-start -->
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- prettier-ignore-end -->
+
+
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -216,45 +251,17 @@ components:
 | <a name="output_team_name_role_arn_map"></a> [team\_name\_role\_arn\_map](#output\_team\_name\_role\_arn\_map) | Map of team names to role ARNs |
 | <a name="output_team_names"></a> [team\_names](#output\_team\_names) | List of team names |
 | <a name="output_teams_config"></a> [teams\_config](#output\_teams\_config) | Map of team config with name, target arn, and description |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-<!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
-## Known Problems
 
-### Error: `assume role policy: LimitExceeded: Cannot exceed quota for ACLSizePerRole: 2048`
-
-The `aws-teams` architecture, when enabling access to a role via lots of AWS SSO Profiles, can create large "assume
-role" policies, large enough to exceed the default quota of 2048 characters. If you run into this limitation, you will
-get an error like this:
-
-```
-Error: error updating IAM Role (acme-gbl-root-tfstate-backend-analytics-ro) assume role policy: LimitExceeded: Cannot exceed quota for ACLSizePerRole: 2048
-```
-
-This can happen in either/both the `identity` and `root` accounts (for Terraform state access). So far, we have always
-been able to resolve this by requesting a quota increase, which is automatically granted a few minutes after making the
-request. To request the quota increase:
-
-- Log in to the AWS Web console as admin in the affected account
-
-- Set your region to N. Virginia `us-east-1`
-
-- Navigate to the Service Quotas page via the account dropdown menu
-
-- Click on AWS Services in the left sidebar
-
-- Search for "IAM" and select "AWS Identity and Access Management (IAM)". (If you don't find that option, make sure you
-  have selected the `us-east-1` region.
-
-- Find and select "Role trust policy length"
-
-- Request an increase to 4096 characters
-
-- Wait for the request to be approved, usually less than a few minutes
 
 ## References
 
-- [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components)- Cloud Posse's upstream
-  component
+
+- [cloudposse-terraform-components](https://github.com/orgs/cloudposse-terraform-components/repositories) - Cloud Posse's upstream component
+
+
+
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-teams&utm_content=)
+


### PR DESCRIPTION
## what
- Update README.yaml

## why
- Use atmos to generate readme


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added two new inputs for component names and a new output exposing role ARNs.

- Documentation
  - Expanded guidelines and contributor docs.
  - Updated README with Known Problems, testing instructions, support links, and reorganized metadata and references.

- Chores
  - Tightened AWS provider compatibility to < 6.0.0.
  - Bumped dependent module versions.
  - Added project configuration for centralized scaffolding.
  - Expanded ignored files/directories.
  - Simplified build scripts by removing unused targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->