### PR TITLE
fix: bump stack-config/yaml remote-state 1.8.0 → 2.0.0 for utils 2.x compatibility

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "aws_saml" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component  = var.aws_saml_component_name
   privileged = true
@@ -16,7 +16,7 @@ module "aws_saml" {
 
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = var.account_map_component_name
   tenant      = module.iam_roles.global_tenant_name

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   sources:
     - component: "account-map"
-      source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
-      version: 1.520.0
+      source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:


### PR DESCRIPTION
## what

- Bump `cloudposse/stack-config/yaml//modules/remote-state` from `1.8.0` → `2.0.0` on both call sites in `src/remote-state.tf` (`aws_saml`, `account_map`).
- Point the terratest fixture (`test/fixtures/vendor.yaml`) `account-map` source at the standalone `cloudposse-terraform-components/aws-account-map` repo at `v1.537.2` (was the legacy monorepo `cloudposse/terraform-aws-components//modules/account-map@1.520.0`).

## why

`src/providers.tf` references `../account-map/modules/iam-roles` as a local module, so `aws-account-map`'s dependency graph merges into this component's provider constraints. As of `aws-account-map` **v1.537.2**, `iam-roles` uses `stack-config/yaml` **2.0.0** (`cloudposse/utils >= 2.0.0, < 3.0.0`), while this component still pinned `stack-config/yaml` **1.8.0** (`utils >= 1.7.1, < 2.0.0`). `terraform init` then fails with an impossible constraint:

```
no available releases match the given constraints
>= 1.7.1, >= 2.0.0, < 2.0.0, < 3.0.0
```

The same move was already made for `aws-account-map` (→ 2.0.0 in v1.537.2). The `remote-state` submodule's interface is unchanged between 1.8.0 and 2.0.0 — only the transitive `cloudposse/utils` floor widens — so this is a non-breaking alignment.

The second commit updates the test fixture for the same reason: the legacy monorepo `account-map` (stack-config 1.5.0) would otherwise reintroduce the `utils < 2.0.0` floor into the terratest init graph and conflict with this bump.

## references

- `aws-account-map` v1.537.2 (already on stack-config/yaml 2.0.0)
- Mirrors the equivalent fix in `aws-aurora-postgres`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal component references to newer released versions.
  * Refreshed vendor configuration to use a newer account map source and version.
  * Bumped remote state module versions in Terraform configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->